### PR TITLE
Fix strftime format string

### DIFF
--- a/twint/output.py
+++ b/twint/output.py
@@ -25,8 +25,8 @@ def datecheck(datetimestamp, config):
     logme.debug(__name__+':datecheck')
     if config.Since and config.Until:
         logme.debug(__name__+':datecheck:dateRangeTrue')
-        d = int(datetime.strptime(datetimestamp, "%Y-%m-%d %H:%M:%S").strftime('%S'))
-        s = int(datetime.strptime(config.Since, "%Y-%m-%d %H:%M:%S").strftime('%S'))
+        d = int(datetime.strptime(datetimestamp, "%Y-%m-%d %H:%M:%S").timestamp())
+        s = int(datetime.strptime(config.Since, "%Y-%m-%d %H:%M:%S").timestamp())
         if d < s:
            return False
     logme.debug(__name__+':datecheck:dateRangeFalse')

--- a/twint/output.py
+++ b/twint/output.py
@@ -25,8 +25,8 @@ def datecheck(datetimestamp, config):
     logme.debug(__name__+':datecheck')
     if config.Since and config.Until:
         logme.debug(__name__+':datecheck:dateRangeTrue')
-        d = int(datetime.strptime(datetimestamp, "%Y-%m-%d %H:%M:%S").strftime('%s'))
-        s = int(datetime.strptime(config.Since, "%Y-%m-%d %H:%M:%S").strftime('%s'))
+        d = int(datetime.strptime(datetimestamp, "%Y-%m-%d %H:%M:%S").strftime('%S'))
+        s = int(datetime.strptime(config.Since, "%Y-%m-%d %H:%M:%S").strftime('%S'))
         if d < s:
            return False
     logme.debug(__name__+':datecheck:dateRangeFalse')


### PR DESCRIPTION
Lines 28 and 29 that were using `.strftime('%s')` where it should be written as `.strftime('%S')`. This error would make twint fail with an `Invalid format string` when using time-related configurations like `Since` and `Until`.